### PR TITLE
Support new redesigned adidas queue product page 

### DIFF
--- a/main.js
+++ b/main.js
@@ -436,16 +436,17 @@ class BruteforceTask {
         this.enableButton('copyCookies');
         this.enableButton('copyHtml');
         let checkForSitekey = () => {
-          this.getHtml((pageSource) => {
-            if (pageSource.includes('data-sitekey')) {
-            //if (true) {
-              this.setStatus('Through Queue');
-              this.setColor('green');
-              this.enableButton('fillAtc');
-            }
-            else
-              setTimeout(checkForSitekey, 20000);
-          });
+          this.nightmare.evaluate(function() {
+              return typeof CAPTCHA_KEY !== 'undefined';
+          })
+            .then(function(hasSiteKey) {
+                if (hasSiteKey) {
+                    this.setStatus('Through Queue');
+                    this.setColor('green');
+                    this.enableButton('fillAtc');
+                } else
+                    setTimeout(checkForSitekey, 20000);
+          });       
         }
         checkForSitekey();
       })


### PR DESCRIPTION
For the past 2 releases Adidas has redesigned the product page not to include data-sitekey, instead a separately loaded js file creates the captcha element

What Adidas have introduced is a global CAPTCHA_KEY variable which value is the sitekey

if window.CAPTCHA_KEY exists, the electron instance has passed splash